### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ These are influenced by [Go] Channle.
 ## Installtion
 
 ```console
-$ npm install --save champloo
+$ npm install --save chanpuru
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ npm install --save champloo
 
 Parallelize command execution by `$` of [zx] with [`Chan`].
 
-![External commands(sha256sum) are being executed in parallel](docs/parallel-jobs.gif)
+![External commands(sha256sum) are being executed in parallel](https://raw.githubusercontent.com/hankei6km/chanpuru/main/docs/parallel-jobs.gif)
 
 #### Send
 
@@ -81,7 +81,7 @@ for await (const f of recvResults) {
 - Stop all commands if any command exit with error status
 - Stop all commands even if timed out
 
-![Displaying while merging the ping execution status to multiple hosts](docs/log-multpiple-sources.gif)
+![Displaying while merging the ping execution status to multiple hosts](https://raw.githubusercontent.com/hankei6km/chanpuru/main/docs/log-multpiple-sources.gif)
 
 #### Send
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -34,7 +34,7 @@ $ npm install --save champloo
 1. Chennl の Receiver を返す
 
 バッファーサイズは `Promise` の実行数を制限していないので注意。
-詳細は[pass-promise-paralle.ts](https://github.com/hankei6km/chanpuru/blob/main/examples/README.md#pass-promise-parallelts)を参照。
+詳細は[pass-promise-paralle.ts](https://raw.githubusercontent.com/hankei6km/chanpuru/main/docs/parallel-jobs.gif)を参照。
 
 ```ts
 function computeHash(
@@ -81,7 +81,7 @@ for await (const f of recvResults) {
 - いずれかのコマンドがエラーになればすべてのコマンドを停止する
 - タイムアウトでも全てのコマンドを停止する
 
-![複数ホストへの ping 実行状況をマージしながら表示している](docs/log-multpiple-sources.gif)
+![複数ホストへの ping 実行状況をマージしながら表示している](https://raw.githubusercontent.com/hankei6km/chanpuru/main/docs/log-multpiple-sources.gif)
 
 #### 送信
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -12,7 +12,7 @@ Promise と Async Generator で並列的な処理を行う。
 ## Installtion
 
 ```console
-$ npm install --save champloo
+$ npm install --save chanpuru
 ```
 
 ## Usage

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # exmaples
 
-`chanppuru` のサンプル。
+chanpuru のサンプル。
 
 ## 実行方法
 


### PR DESCRIPTION
- Use abs path to images
- Typo
