### PR TITLE
test: Use primary matcher names instead of alias functions

### DIFF
--- a/test/lib/cancel.spec.ts
+++ b/test/lib/cancel.spec.ts
@@ -60,16 +60,16 @@ describe('abortPromise()', () => {
     await Promise.resolve()
     expect(canceled).toBeFalsy()
     expect(reason).toBeUndefined()
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(0)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(0)
 
     cancel()
 
     await c.catch(() => {})
     expect(canceled).toBeTruthy()
     expect(reason).toBeUndefined()
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
     expect(mockRemoveEventListener.mock.calls[0]).toEqual(
       mockAddEventListener.mock.calls[0]
     )
@@ -77,8 +77,8 @@ describe('abortPromise()', () => {
     abort() // 結果は変わらない
 
     expect(await c).toBeUndefined()
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
     expect(canceled).toBeTruthy()
     expect(reason).toBeUndefined()
   })
@@ -103,8 +103,8 @@ describe('abortPromise()', () => {
     await Promise.resolve()
     expect(canceled).toBeFalsy()
     expect(reason).toBeUndefined()
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(0)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(0)
 
     abort()
 
@@ -112,8 +112,8 @@ describe('abortPromise()', () => {
     expect(canceled).toBeFalsy()
     expect(reason instanceof CancelPromiseRejected).toBeTruthy()
     expect(reason.reason).toEqual('Aborted')
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
     expect(mockRemoveEventListener.mock.calls[0]).toEqual(
       mockAddEventListener.mock.calls[0]
     )
@@ -130,8 +130,8 @@ describe('abortPromise()', () => {
     expect(reason.reason).toEqual('Aborted')
     expect(canceled).toBeFalsy()
     expect(reason.reason).toEqual('Aborted')
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/test/lib/chan.spec.ts
+++ b/test/lib/chan.spec.ts
@@ -44,11 +44,11 @@ describe('Chan()', () => {
     const c = new Chan<string>()
     c.close()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -59,11 +59,11 @@ describe('Chan()', () => {
     c.close()
     await expect(c.send('0')).rejects.toThrow('panic: send on closed channel')
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -82,11 +82,11 @@ describe('Chan()', () => {
     expect((await i.next()).value).toEqual('0')
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -105,11 +105,11 @@ describe('Chan()', () => {
     expect((await i.next()).value).toEqual('0')
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -130,11 +130,11 @@ describe('Chan()', () => {
     expect((await i.next()).value).toEqual('1')
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -163,11 +163,11 @@ describe('Chan()', () => {
     expect(v[0].value).toEqual('0')
     expect(v[1].value).toEqual('1')
     expect(v[2].done).toBeTruthy()
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -181,11 +181,11 @@ describe('Chan()', () => {
     const i = c.receiver()
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -206,11 +206,11 @@ describe('Chan()', () => {
     expect((await i.next()).value).toEqual('1')
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -231,11 +231,11 @@ describe('Chan()', () => {
     expect((await i.next()).value).toEqual('1')
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -256,11 +256,11 @@ describe('Chan()', () => {
     }
     expect(res).toEqual(s)
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -281,11 +281,11 @@ describe('Chan()', () => {
     }
     res.sort(sortFunc)
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -308,11 +308,11 @@ describe('Chan()', () => {
     }
     res.sort(sortFunc)
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -354,11 +354,11 @@ describe('Chan()', () => {
     expect(r2Cnt).toBeGreaterThan(0)
     expect(res).toEqual(s)
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -406,11 +406,11 @@ describe('Chan()', () => {
     res.sort(sortFunc)
     expect(res).toEqual(s)
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -442,11 +442,11 @@ describe('Chan()', () => {
 
     expect(pocket).toEqual([0, 1, 2])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -478,11 +478,11 @@ describe('Chan()', () => {
 
     expect(pocket).toEqual([0, 0, 1])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -522,11 +522,11 @@ describe('Chan()', () => {
     for await (let v of i) {
     }
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -570,11 +570,11 @@ describe('Chan()', () => {
     expect(senderError).toEqual('rejected')
     expect(receiverError).toBeUndefined()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -616,11 +616,11 @@ describe('Chan()', () => {
     expect(senderError).toEqual('rejected')
     expect(receiverError).toBeUndefined()
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -661,11 +661,11 @@ describe('Chan()', () => {
     expect(senderError).toEqual('rejected')
     expect(receiverError).toEqual('rejected')
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -706,11 +706,11 @@ describe('Chan()', () => {
     expect(senderError).toEqual('rejected')
     expect(receiverError).toEqual('rejected')
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -739,11 +739,11 @@ describe('Chan()', () => {
     }
     expect(res).toEqual(['0', '1', '2', '4', '5', '6', '7'])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -772,11 +772,11 @@ describe('Chan()', () => {
     }
     expect(res).toEqual(['0', '1', '2', '4', '5', '6', '7'])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -806,11 +806,11 @@ describe('Chan()', () => {
     res.sort(sortFunc)
     expect(res).toEqual(['0', '1', '2', '4', '5', '6'])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -841,11 +841,11 @@ describe('Chan()', () => {
     res.sort(sortFunc)
     expect(res).toEqual(['0', '1', '2', '4', '5', '6'])
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()
@@ -874,11 +874,11 @@ describe('Chan()', () => {
     jest.advanceTimersByTime(1000)
     expect(await Promise.race(v)).toEqual('0')
 
-    expect(mockBufReset).toBeCalled()
+    expect(mockBufReset).toHaveBeenCalled()
     expect(
       mockBufReset.mock.calls.length <= mockBufRelease.mock.calls.length
     ).toBeTruthy()
-    expect(mockValueReset).toBeCalled()
+    expect(mockValueReset).toHaveBeenCalled()
     expect(
       mockValueReset.mock.calls.length <= mockValueRelease.mock.calls.length
     ).toBeTruthy()

--- a/test/lib/generators.spec.ts
+++ b/test/lib/generators.spec.ts
@@ -63,8 +63,8 @@ describe('beatsGenerator()', () => {
     // jest.advanceTimersByTime(1000) // cancel されたので待たない.
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockSetTimeout).toBeCalledTimes(5)
-    expect(mockClearTimeout).toBeCalledTimes(1)
+    expect(mockSetTimeout).toHaveBeenCalledTimes(5)
+    expect(mockClearTimeout).toHaveBeenCalledTimes(1)
     expect(mockSetTimeout.mock.calls[0][1]).toEqual(1000)
 
     cancel()
@@ -97,8 +97,8 @@ describe('beatsGenerator()', () => {
     jest.advanceTimersByTime(1000)
     expect((await i.next()).done).toBeTruthy()
 
-    expect(mockSetTimeout).toBeCalledTimes(3)
-    expect(mockClearTimeout).toBeCalledTimes(0)
+    expect(mockSetTimeout).toHaveBeenCalledTimes(3)
+    expect(mockClearTimeout).toHaveBeenCalledTimes(0)
     expect(mockSetTimeout.mock.calls[0][1]).toEqual(1000)
 
     cancel()
@@ -131,8 +131,8 @@ describe('beatsGenerator()', () => {
 
     expect(sended).toBeTruthy()
 
-    expect(mockSetTimeout).toBeCalledTimes(1)
-    expect(mockClearTimeout).toBeCalledTimes(0)
+    expect(mockSetTimeout).toHaveBeenCalledTimes(1)
+    expect(mockClearTimeout).toHaveBeenCalledTimes(0)
     expect(mockSetTimeout.mock.calls[0][1]).toEqual(1000)
 
     cancel()
@@ -175,8 +175,8 @@ describe('beatsGenerator()', () => {
 
     expect((await partial).done).toBeTruthy()
 
-    expect(mockSetTimeout).toBeCalledTimes(1)
-    expect(mockClearTimeout).toBeCalledTimes(1)
+    expect(mockSetTimeout).toHaveBeenCalledTimes(1)
+    expect(mockClearTimeout).toHaveBeenCalledTimes(1)
     expect(mockSetTimeout.mock.calls[0][1]).toEqual(1000)
 
     cancel()
@@ -195,8 +195,8 @@ describe('beatsGenerator()', () => {
     expect(v.value).toEqual(2) // done のときにもカウントが返ってくる.
     expect(v.done).toBeTruthy()
 
-    expect(mockSetTimeout).toBeCalledTimes(3)
-    expect(mockClearTimeout).toBeCalledTimes(0)
+    expect(mockSetTimeout).toHaveBeenCalledTimes(3)
+    expect(mockClearTimeout).toHaveBeenCalledTimes(0)
     expect(mockSetTimeout.mock.calls[0][1]).toEqual(0)
 
     cancel()
@@ -376,8 +376,8 @@ describe('breakGenerator()', () => {
     expect(f).toBeTruthy()
     abort()
     expect(await g.next()).toEqual({ done: true, value: undefined })
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
     expect(mockRemoveEventListener.mock.calls[0]).toEqual(
       mockAddEventListener.mock.calls[0]
     )
@@ -489,8 +489,8 @@ describe('breakGenerator()', () => {
     expect(await g.next()).toEqual({ done: true, value: 10 })
     expect(f).toBeTruthy()
     expect(await g.next()).toEqual({ done: true, value: undefined })
-    expect(mockAddEventListener).toBeCalledTimes(1)
-    expect(mockRemoveEventListener).toBeCalledTimes(1)
+    expect(mockAddEventListener).toHaveBeenCalledTimes(1)
+    expect(mockRemoveEventListener).toHaveBeenCalledTimes(1)
     expect(mockRemoveEventListener.mock.calls[0]).toEqual(
       mockAddEventListener.mock.calls[0]
     )


### PR DESCRIPTION
https://jestjs.io/docs/upgrading-to-jest30
